### PR TITLE
Improve scorm performance by generating async events API calls

### DIFF
--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -83,7 +83,6 @@ function ScormXBlock(runtime, element, settings) {
       type: "POST",
       url: handlerUrl,
       data: JSON.stringify({'name': cmi_element, 'value': value}),
-      async: false,
       success: function(response){
         if (typeof response.lesson_score != "undefined"){
           $(".lesson_score", element).html(response.lesson_score);


### PR DESCRIPTION
**Improved Scorm performance by:**
- Making Scom API calls async

**For the Background:**
- Scorm was taking too long to switch between slides and to submit problem (with in scorm).
- Delay was due to number of API calls e.g  scorm was generating 15 API calls on every problem submit.
- All API calls were generating through **sync** ajax calls which resulted in delay of 3 secs (local) and 8-9 secs (on servers).
