### PR TITLE
Fixed scorm file duplication issue

### DIFF
--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -95,7 +95,7 @@ function ScormXBlock(runtime, element, settings) {
   };
 
   $(function ($) {
-    $('.scorm_object').attr('src', `${window.location.origin}${settings.scorm_path}`);
+    $('.scorm_object', element).attr('src', `${window.location.origin}${settings.scorm_path}`);
     
     if (settings.version_scorm == 'SCORM_12') {
       API = new SCORM_12_API();


### PR DESCRIPTION
### **Fixes SCORM File Duplication Issue**

This PR resolves the issue where multiple SCORM blocks within a single unit display the last added file in all blocks, instead of showing the correct SCORM file for each block.

### **Steps to Reproduce:**
1. Add a valid SCORM file to a unit as a component (e.g., component 1).
2. Add another SCORM file as a separate component (e.g., component 2).
3. Add another SCORM file as a separate component (e.g., component 3).
4. Click on "Preview" and observe the behavior.

### **Expected Behavior:**
Each block should display its respective SCORM file.

### **Actual Behavior:**
All blocks display the last added SCORM file, replacing the previous ones.

JIRA: https://edlyio.atlassian.net/browse/EDLY-6550

### **Screenshot before Fix:**
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/e9d4d922-d795-46e9-887a-bf0a5d474a7c">

### **Screenshot after Fix:**
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/1c4005d3-f801-44d3-95d7-0c614a804817">



