### PR TITLE
fix: Proxy SCORM assets through LMS handler to preserve same-origin with S3

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -333,6 +333,32 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
 
         return context
 
+    @XBlock.handler
+    def assets_proxy(self, request, suffix=''):
+        """
+        Proxy SCORM assets from default_storage (S3) through the LMS domain.
+
+        When S3 storage is active, SCORM files live on S3 and the local copy is
+        deleted after upload. Loading the iframe directly from an S3 URL would make
+        it cross-origin, breaking window.parent.API so SCORM cannot report scores.
+
+        This handler streams any file within the SCORM package from default_storage
+        back to the browser under the LMS domain, preserving same-origin access.
+
+        The suffix is the relative path within the SCORM package root, e.g.:
+            "index.html", "scormdriver/indexAPI.html", "scripts/api.js"
+        """
+        if not suffix:
+            return Response(status=404)
+        file_path = os.path.join(self._file_storage_path(), suffix)
+        try:
+            with default_storage.open(file_path) as f:
+                content = f.read()
+        except Exception:
+            return Response(status=404)
+        content_type, _ = mimetypes.guess_type(suffix)
+        return Response(content, content_type=content_type or 'application/octet-stream')
+
     def publish_grade(self):
         if not ENABLE_PUBLISH_FAILED_SCORM_SCORE and (
             self.lesson_status == "failed" or (
@@ -377,7 +403,16 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     def get_context_student(self):
         scorm_file_path = ""
         if self.scorm_file:
-            scorm_file_path = self.scorm_file
+            if self.s3_storage:
+                # When S3 is active, proxy assets through the LMS handler so the
+                # iframe stays same-origin and window.parent.API remains accessible
+                # for SCORM score/completion reporting.
+                from urllib.parse import urlparse
+                proxy_base = self.runtime.handler_url(self, 'assets_proxy').rstrip('?/')
+                proxy_path = urlparse(proxy_base).path
+                scorm_file_path = "{}/{}".format(proxy_path, self.path_index_page)
+            else:
+                scorm_file_path = self.scorm_file
 
         return {
             "scorm_file_path": scorm_file_path,

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import json
 import hashlib
 import mimetypes
+import posixpath
 import re
 import os
 import stat
@@ -350,7 +351,12 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         """
         if not suffix:
             return Response(status=404)
-        file_path = os.path.join(self._file_storage_path(), suffix)
+        # Sanitize: strip leading slashes (prevents os.path.join from discarding
+        # the base path) and normalize to collapse ".." path traversal sequences.
+        base = self._file_storage_path()
+        file_path = posixpath.normpath(posixpath.join(base, suffix.lstrip('/')))
+        if not file_path.startswith(base + '/'):
+            return Response(status=403)
         try:
             with default_storage.open(file_path) as f:
                 content = f.read()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='0.5',
+    version='1.1.5',
     description='scormxblock XBlock',   # TODO: write a better description.
     packages=[
         'scormxblock',


### PR DESCRIPTION
## Problem

When S3 storage is configured, SCORM files are uploaded to S3 and the local copy is deleted. In k8s production (Tutor/Ulmo), the LMS does not serve `/media/` files, so the stored `scorm_file` URL (`/media/scormxblockmedia/...`) returns **404** — SCORM content fails to load.

Using a direct S3 URL is also wrong: the iframe becomes cross-origin, which breaks `window.parent.API` — SCORM cannot report scores or completion.

In the legacy Koa environment, nginx transparently proxies `/media/scormxblockmedia/` to S3, keeping same-origin. This infrastructure dependency is fragile and not portable to Tutor/k8s.

## Solution

Inspired by [overhangio/openedx-scorm-xblock](https://github.com/overhangio/openedx-scorm-xblock), add an `assets_proxy` XBlock handler that streams SCORM files from `default_storage` (S3) through the LMS domain. The iframe stays same-origin, so `window.parent.API` remains accessible for SCORM score/completion reporting.

### Changes

1. **`assets_proxy` handler** — new `@XBlock.handler` that receives the relative file path as suffix (e.g. `index.html`, `scormdriver/indexAPI.html`), reads from `default_storage`, and streams back with correct `Content-Type`. Includes path traversal protection: strips leading slashes, normalizes with `posixpath` to collapse `..` sequences, and verifies the resolved path stays within the SCORM package directory.

2. **`get_context_student()`** — when `s3_storage` is True, computes the iframe URL dynamically using `runtime.handler_url(self, 'assets_proxy')` instead of the stored `/media/` path. The URL is computed at view time, not stored.

3. **`set_fields_xblock()`** — unchanged. `scorm_file` continues to store the local `/media/` path for non-S3 environments.

4. **Version bump** — `0.5` → `1.1.5`

### How it works

```
Before (broken on k8s):
  iframe src → /media/scormxblockmedia/org/course/block/index.html → 404

After:
  iframe src → /courses/.../xblock/.../handler/assets_proxy/index.html
                → Django reads from S3 via default_storage
                → streams content back under LMS domain
                → same-origin preserved → window.parent.API works
```

Nested SCORM resources (scripts, images, CSS) resolve as relative URLs under the handler path and are served the same way.

### Security

The `assets_proxy` handler sanitizes the URL suffix to prevent path traversal attacks:
- Strips leading `/` (prevents `os.path.join` from discarding the base path)
- Normalizes with `posixpath.normpath` (collapses `..` sequences)
- Verifies the resolved path starts with the SCORM package directory (returns 403 otherwise)

This prevents cross-tenant file access in multi-tenant deployments.

## Backward compatibility

- Works for existing SCORM blocks without re-upload (`path_index_page` is already stored correctly)
- Non-S3 environments are unaffected (`scorm_file` used as-is)
- No JS or template changes

## Test plan

- [ ] Upload SCORM package in Studio with S3 storage configured
- [ ] Verify iframe src in browser Network tab shows `/courses/.../handler/assets_proxy/...` (not `/media/...`)
- [ ] Verify SCORM content loads and displays correctly
- [ ] Verify scores/completion are tracked (check progress tab)
- [ ] Verify local storage (non-S3) still works unchanged
- [ ] Verify path traversal is blocked (e.g. `assets_proxy/../../other-org/...` returns 403)

> **Note:** Use "Squash and merge" when merging this PR.